### PR TITLE
feature: formLogin 방식을 통한 Security 인증 방식 구현

### DIFF
--- a/src/main/java/com/security/basicsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/security/basicsecurity/config/SecurityConfig.java
@@ -4,6 +4,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @Configuration
 @EnableWebSecurity
@@ -15,6 +24,28 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.authorizeRequests()
                 .anyRequest().authenticated();
 
-        http.formLogin();
+        http.formLogin()
+//                .loginPage("/loginPage")
+                .defaultSuccessUrl("/")
+                .failureUrl("/loginPage")
+                .usernameParameter("userId")
+                .passwordParameter("passwd")
+                .loginProcessingUrl("/login_proc")
+                .successHandler(new AuthenticationSuccessHandler() {
+                    @Override
+                    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+                        System.out.println("authentication" + authentication.getName());
+                        response.sendRedirect("/");
+                    }
+                })
+                .failureHandler(new AuthenticationFailureHandler() {
+                    @Override
+                    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+                        System.out.println("exception.getMessage() = " + exception.getMessage());
+                        response.sendRedirect("/login");
+                    }
+                })
+                .permitAll()
+        ;
     }
 }

--- a/src/main/java/com/security/basicsecurity/controller/SecurityController.java
+++ b/src/main/java/com/security/basicsecurity/controller/SecurityController.java
@@ -10,4 +10,9 @@ public class SecurityController {
     public String index() {
         return "home";
     }
+
+    @GetMapping("/loginPage")
+    public String loginPage() {
+        return "loginPage";
+    }
 }


### PR DESCRIPTION
# Security 인증 API

### Form 인증
  - 인증이 안되면 로그인 페이지로 리다이렉트
    - 로그인 페이지는 커스텀으로 설정하지 않을 경우 Security에서 제공하는 Default Login페이지로 이동
  - 로그인 페이지에서 POST 방식으로 username + password를 Request로 전달
  - 로그인 성공시 SESSION 또는 인증 토큰 생성 및 저장
  - 세션에 저장된 인증 토큰으로 홈 페이지 접근 및 인증 유지

### Form Login 인증의 Method

```java
protected void configure(HttpSecurity http) throws Exception() {

  http.formLogin()                          // Form 로그인 인증 기능이 동작
    .loginPage("/login.html")               // 사용자 정의 로그인 페이지
    .defaultSuccessUrl("/home")             // 로그인 성공 후 이동 페이지
    .failureUrl("/login.html?error=true")   // 로그인 실패 후 이동 페이지
    .usernameParameter("username")          // 아이디 파라미터명 설정
    .passwordParameter("password")          // 패스워드 파라미터명 설정
    .loginProcessingUrl("/login")           // Login Form Action Url
    .successHandler(loginSuccessHandler())  // 로그인 성공 후 핸들러
    .failureHandler(loginFailureHandler())  // 로그인 실패 후 핸들러
}
```